### PR TITLE
Fix variable paths in router use

### DIFF
--- a/src/functions.ts
+++ b/src/functions.ts
@@ -188,7 +188,17 @@ function listEndpoints (app: Application, swaggerConfig: SwaggerConfig): Swagger
         }
       } else if (layer.name === 'router') {
         const subRouter: any = layer.handle
-        const subPath = `${basePath}${layer.regexp.toString().slice(1, -4) as string}`
+        const regexp = layer.keys?.length > 0
+          ? new RegExp(
+            layer.regexp.source.replace(/\(\?:\(([^)]+)\)\)/g, () => {
+              return layer.keys.length > 0
+                ? `{${layer.keys.shift().name as string}}`
+                : ''
+            }),
+            layer.regexp.flags
+          )
+          : layer.regexp
+        const subPath = `${basePath}${regexp.toString().slice(1, -4) as string}`
 
         exploreRoutes(
           subRouter,


### PR DESCRIPTION
Path variable errors in the initial hierarchies of router.use have been successfully resolved.

[Task 327](https://www.notion.so/comparaonline/Fix-Variable-path-in-lib-d4f44ad90c454d7c9bcd3172c2764e20?pvs=4)