### PR TITLE
docs: add llms.txt and update package description for AI discoverability

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,26 @@
+# openapi-generator
+
+> Auto-generates OpenAPI 3.0 documentation and request validation middleware for Express routes using Joi or Zod schemas.
+
+## Metadata
+- type: lib
+- domain: domain-devops
+- status: active
+
+## Dependencies
+- express
+
+## Responsibilities
+- Generate OpenAPI 3.0 spec from Express route handlers
+- Provide request validation middleware for path params, query params, and headers
+- Serve Swagger UI at a configurable endpoint
+- Support Joi and Zod v4 schema definitions
+
+## Out of scope
+- Authentication or authorization
+- Database access
+- Business logic
+
+## Usage
+- Install: `yarn add @comparaonline/openapi-generator`
+- Exports: createHandler, runSwagger, setupOpenApi, RequestHandlerWithDocumentation, ValidationSchema, SwaggerDoc, SwaggerConfig, ResponseType

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@comparaonline/openapi-generator",
   "version": "1.1.0",
-  "description": "Soap and rest connector",
+  "description": "Generates OpenAPI 3.0 docs and request validation middleware for Express routes",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/comparaonline/openapi-generator.git",


### PR DESCRIPTION
## Problem

The repository had no machine-readable metadata for AI agents and an outdated `package.json` description ("Soap and rest connector") that didn't reflect the library's actual purpose, making it hard to discover or classify automatically.

## Solution

Added `llms.txt` at the repo root following the RFC standard for AI agent discoverability. The file classifies the library as `type-lib` / `domain-devops` and documents its responsibilities, out-of-scope areas, and public API surface in a structured format.

Updated the `package.json` description to accurately describe the library. GitHub topics (`type-lib`, `domain-devops`) and the repo description were also updated via the API.

## How to Test

1. Confirm `llms.txt` exists at the repo root and renders correctly as Markdown
2. Confirm `package.json` description reads "Generates OpenAPI 3.0 docs and request validation middleware for Express routes"
3. Run `gh repo view comparaonline/openapi-generator` to verify topics and GitHub description

## Related

RFC: https://www.notion.so/comparaonline/699b867b059946679e0ef193e9793f1e?v=8d48bc303792442fab32ed6c9ea5fda6&p=32219df1525381d889a5f69337b63893&pm=s