### PR TITLE
feat(create-handler)!: respond 400 on validation failure instead of next(err)

### DIFF
--- a/docs/adr/ADR-0001-respond-400-on-validation-failure.md
+++ b/docs/adr/ADR-0001-respond-400-on-validation-failure.md
@@ -96,9 +96,6 @@ keep propagating to the consumer's error handler and keep appearing in APM.
 - Four consumer PRs are needed to bump `^1.0.x` → `^2.0.0` (`users`,
   `login-service`, `offer-builder`, `order-orchestrator`).
 - `ExceptionError` became dead code and was removed from `create-handler.ts`.
-- Notion RFC cross-check for existing observability/validation conventions was
-  pending at authoring time (Notion API rate-limited); revisit if a related RFC
-  exists.
 
 ---
 

--- a/docs/adr/ADR-0001-respond-400-on-validation-failure.md
+++ b/docs/adr/ADR-0001-respond-400-on-validation-failure.md
@@ -1,0 +1,152 @@
+# ADR-0001: Respond 400 directly on validation failure instead of `throw` + `next(err)`
+
+**Status:** Accepted
+**Date:** 2026-07-07
+**Deciders:** Sebastián Contreras (implementer), Enzo Martini (reporter, issue #16)
+
+---
+
+## Context and Problem Statement
+
+`@comparaonline/openapi-generator` ships an Express validation middleware
+(`schemaMiddleware` in `src/create-handler.ts`). Since the first version (#1/#2)
+it validated the request and, on failure, did `throw new ExceptionError(400, …)`
+caught by `catch (e) { return next(e) }`. PR #10 added the Zod branch and
+duplicated the same pattern. A failed validation therefore reached the
+consumer's Express error handler as a delegated error.
+
+In Express, any `next(err)` with a truthy error is intercepted by the dd-trace
+instrumentation, which marks the middleware span with `error=1` **at the moment
+of `next(err)`** — before any consumer code runs. As a result, every controlled
+`400` (invalid client input, expected behavior) produces an error span in APM
+and creates issues in Error Tracking, even though the service did not fail. In
+`users` (production, 24h) this was ~1100 error spans from validation messages
+like `"body" must contain at least one of [phone, email]`.
+
+Because dd-trace marks the span inside the library middleware, this **cannot be
+mitigated on the consumer side** except by disabling all middleware spans
+(`tracer.use('express', { middleware: false })`), which sacrifices per-middleware
+timing in the flame graph. A review of the four known consumers (`users`,
+`login-service`, `offer-builder`, `order-orchestrator`) confirmed that all four
+are affected — each also logs the validation `ExceptionError` at error level in
+its own error handler — and that none of them do anything in the error handler
+beyond logging and responding. The consumer set is closed and fully audited.
+
+## Decision Drivers
+
+- A `4xx` from validation is a client error and must not be recorded as a service
+  error in APM: eliminate the ~1100 error spans/day in `users` and the equivalent
+  error-level logs across the four consumers.
+- The fix must be central: the `next(err)` lives inside the library, so consumers
+  cannot fix it without duplicating a wrapper in every repo (DRY violation) — and
+  the duplicate would still run after the span is already marked.
+- Preserve per-middleware timing in the APM flame graph (do not disable middleware
+  spans).
+- Preserve the existing response contract for the four known consumers:
+  HTTP `400` with body `{ message, code: 'bad-request' }`.
+- Minimize consumer churn: no per-route refactor. `login-service` uses the
+  positional `createHandler(schema)` form in 36 of 43 routes, so any per-route
+  option would force a positional→object rewrite.
+- The consumer set is known and closed (4 repos, all reviewed), which makes a
+  breaking change low-risk.
+
+## Considered Options
+
+- **Option A:** Respond `400` directly in the middleware, as the new default
+  (breaking, `2.0.0`).
+- **Option B:** Add a configurable opt-in (flag or custom handler) while keeping
+  `next(err)` as the default (non-breaking, `1.2.0`).
+- **Option C:** Leave the library unchanged; each consumer disables dd-trace
+  middleware spans (`tracer.use('express', { middleware: false })`).
+
+## Decision Outcome
+
+**Chosen option:** Option A — respond `400` directly by default, because the
+`next(err)` that pollutes APM lives inside the library and the consumer set is
+closed and audited, so the configurability of Option B adds ceremony without
+value while Option C degrades observability for everyone.
+
+Validation failures now do `res.status(400).json({ message, code: 'bad-request' })`
+and `return` without calling `next()`. Genuine unexpected errors are still
+delegated with `next(err)` inside the same `try/catch`, so real server errors
+keep propagating to the consumer's error handler and keep appearing in APM.
+
+### Consequences
+
+**Positive:**
+- Removes ~1100 APM error spans/day in `users` and the equivalent across the
+  other three consumers, plus the error-level logs each consumer emitted for
+  client `400`s.
+- Central fix: no per-consumer duplication; future consumers get correct behavior
+  for free.
+- Per-middleware APM timing is preserved.
+- Response contract (`400`, `{ message, code }`) is unchanged for consumers that
+  did not add a `source` field.
+
+**Negative:**
+- Breaking change (`2.0.0`): consumers on `^1.x` do not receive it until they bump
+  the range to `^2.0.0`.
+- The response body drops the constant `source: 'unknown'` for `users` and
+  `order-orchestrator` (their error handlers added it; it was always `'unknown'`
+  for validation errors).
+- Consumers that intentionally wanted their own error handler to format validation
+  `400`s lose that hook. None of the four current consumers do — verified.
+
+**Neutral / requiring follow-up:**
+- Four consumer PRs are needed to bump `^1.0.x` → `^2.0.0` (`users`,
+  `login-service`, `offer-builder`, `order-orchestrator`).
+- `ExceptionError` became dead code and was removed from `create-handler.ts`.
+- Notion RFC cross-check for existing observability/validation conventions was
+  pending at authoring time (Notion API rate-limited); revisit if a related RFC
+  exists.
+
+---
+
+## Options Analysis
+
+### Option A: Respond 400 directly (chosen)
+
+The middleware responds `res.status(400).json({ message, code: 'bad-request' })`
+on validation failure and returns without `next()`. Shipped as `2.0.0`.
+
+**Pros:**
+- Kills the APM error span at its source (no `next(err)` for validation).
+- No configuration surface, no per-route changes in consumers.
+- Also removes the redundant error-level logs in every consumer's error handler.
+- Correct-by-default for future consumers.
+
+**Cons:**
+- Breaking change; requires a major version bump and consumer range bumps.
+- Removes the consumer's ability to intercept validation `400`s via its error
+  handler (acceptable: no current consumer relies on it).
+
+### Option B: Configurable opt-in (flag or custom handler)
+
+Keep `next(err)` as default; add `respondOnValidationError` or `onValidationError`
+to `Params` (and/or a global setter). Shipped as `1.2.0`, non-breaking.
+
+**Pros:**
+- No breaking change; consumers opt in when ready.
+- Leaves the door open for hypothetical external consumers who want the old flow.
+
+**Cons:**
+- A per-route flag in `Params` cannot reach the positional `createHandler(schema)`
+  form, which dominates `login-service` — forcing a positional→object rewrite.
+- Still requires touching all four consumers (to bump + activate), so the opt-in
+  buys nothing over Option A for the closed, known consumer set.
+- Adds permanent configuration surface and two code paths to maintain (YAGNI).
+
+### Option C: Disable dd-trace middleware spans in consumers
+
+Leave the library as-is; each consumer sets
+`tracer.use('express', { middleware: false })`.
+
+**Pros:**
+- No library change.
+
+**Cons:**
+- Sacrifices per-middleware timing in the flame graph for the whole service.
+- Must be repeated in every consumer and every future consumer (DRY violation).
+- Treats the symptom (span noise) rather than the cause (a `4xx` modeled as an
+  exception).
+- Does not remove the redundant error-level logs in each consumer's error handler.

--- a/llms.txt
+++ b/llms.txt
@@ -13,6 +13,7 @@
 ## Responsibilities
 - Generate OpenAPI 3.0 spec from Express route handlers
 - Provide request validation middleware for path params, query params, and headers
+- Respond 400 directly on validation failure (since v2.0.0; does not call next(err), keeps 4xx out of APM error tracking)
 - Serve Swagger UI at a configurable endpoint
 - Support Joi and Zod v4 schema definitions
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@comparaonline/openapi-generator",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Generates OpenAPI 3.0 docs and request validation middleware for Express routes",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/readme.md
+++ b/readme.md
@@ -131,6 +131,25 @@ export {productsRouter}
 
 The joi will not only validate that your parameters are correct but will also generate the documentation
 
+### Validation errors
+
+> **Breaking change in v2.0.0.** Until v1.x the validation middleware threw an
+> `ExceptionError` and delegated it with `next(err)`, so a failed validation
+> reached your Express error handler. This caused APM tools (e.g. dd-trace) to
+> mark the middleware span as an error on every client-side 4xx.
+
+Since v2.0.0 the middleware **responds `400` directly** when validation fails,
+without calling `next(err)`. A validation failure is a client error, not a
+service error, so it no longer propagates as an exception nor pollutes APM
+error tracking. The response body keeps the same shape as before:
+
+```json
+{ "message": "\"body.email\" must be a valid email", "code": "bad-request" }
+```
+
+Unexpected errors (anything other than a validation failure) are still
+delegated with `next(err)` and reach your error handler as usual.
+
 ### Query Params
 
 To add query params you must follow the same logic as for path params in this way, the following example contains path and query params

--- a/src/__tests__/create-handler.test.ts
+++ b/src/__tests__/create-handler.test.ts
@@ -66,13 +66,19 @@ describe.each(schemaVariants)('create-handler ($name)', ({ schema }) => {
     expect(handler.schema).toEqual(schema)
   })
 
-  it('should throw an ExceptionError if validation fails', () => {
+  it('should respond 400 directly when validation fails, without calling next(e)', async () => {
     const next = jest.fn()
+    const json = jest.fn()
+    const status = jest.fn().mockReturnValue({ json })
+    const res = { status } as any
     const req = { body: { name: 1 } }
     const handler = createHandler(schema)
-    handler(req as any, {} as any, next)
-    expect(handler).toBeInstanceOf(Function)
-    expect(next).toHaveBeenCalledWith(expect.any(Error))
+    await handler(req as any, res, next)
+    expect(status).toHaveBeenCalledWith(400)
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({ code: 'bad-request', message: expect.any(String) })
+    )
+    expect(next).not.toHaveBeenCalled()
   })
 
   it('should ok - validation ok', () => {

--- a/src/__tests__/create-handler.test.ts
+++ b/src/__tests__/create-handler.test.ts
@@ -145,4 +145,16 @@ describe('create-handler (schema-agnostic)', () => {
     expect(handler).toBeInstanceOf(Function)
     expect(next).not.toHaveBeenCalledWith(expect.any(Error))
   })
+
+  it('should delegate unexpected (non-validation) errors to next(err) without responding', async () => {
+    const boom = new Error('unexpected failure during parsing')
+    const throwingSchema = { safeParse: () => { throw boom } } as any
+    const next = jest.fn()
+    const status = jest.fn()
+    const res = { status } as any
+    const handler = createHandler(throwingSchema)
+    await handler({} as any, res, next)
+    expect(next).toHaveBeenCalledWith(boom)
+    expect(status).not.toHaveBeenCalled()
+  })
 })

--- a/src/create-handler.ts
+++ b/src/create-handler.ts
@@ -8,12 +8,6 @@ interface ZodIssue { path: Array<string | number>, message: string }
 interface ZodLike { safeParse: (data: unknown) => { success: true, data: any } | { success: false, error: { issues: ZodIssue[] } } }
 type ValidationSchema = ObjectSchema | ZodLike
 
-class ExceptionError extends Error {
-  constructor (public statusCode: number, message: string, public code: string) {
-    super(message)
-  }
-}
-
 interface Params {
   schema: ValidationSchema | undefined
   contentType?: string
@@ -24,8 +18,12 @@ interface Params {
 
 type RequestHandlerWithDocumentation = RequestHandler & { schema?: ValidationSchema, contentType?: string, responseType?: ResponseType, description?: string, operationId?: string }
 
+function respondBadRequest (res: Response, message: string): void {
+  res.status(StatusCodes.BAD_REQUEST).json({ message, code: 'bad-request' })
+}
+
 function schemaMiddleware (schema: ValidationSchema | undefined): RequestHandlerWithDocumentation {
-  const middleware: RequestHandlerWithDocumentation = (async (req: Request, _res: Response, next: NextFunction): Promise<void> => {
+  const middleware: RequestHandlerWithDocumentation = (async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     try {
       if (schema == null) {
         return next()
@@ -33,7 +31,8 @@ function schemaMiddleware (schema: ValidationSchema | undefined): RequestHandler
       if (isSchema(schema)) {
         const { error, value } = schema.validate(req)
         if (error != null) {
-          throw new ExceptionError(StatusCodes.BAD_REQUEST, error.message, 'bad-request')
+          respondBadRequest(res, error.message)
+          return
         }
         req.body = value.body
         req.params = value.params
@@ -43,7 +42,8 @@ function schemaMiddleware (schema: ValidationSchema | undefined): RequestHandler
         const result = schema.safeParse(req)
         if (!result.success) {
           const message = result.error.issues.map((i: ZodIssue) => `${i.path.map(String).join('.')}: ${i.message}`).join('; ')
-          throw new ExceptionError(StatusCodes.BAD_REQUEST, message, 'bad-request')
+          respondBadRequest(res, message)
+          return
         }
         req.body = result.data.body
         req.params = result.data.params


### PR DESCRIPTION
## Problem

Every controlled validation `400` (invalid client input — expected behavior) was being recorded as a **service error** in APM. The validation middleware threw an `ExceptionError` and delegated it with `next(err)`; dd-trace's Express instrumentation marks the middleware span as `error=1` at the moment of `next(err)`, before any consumer code runs. In `users` alone this produced ~1100 error spans/day (plus redundant error-level logs) for messages like `"body" must contain at least one of [phone, email]`.

A `4xx` is the client's fault, not a service failure — it should not pollute Error Tracking.

## Solution

Respond `400` **directly** from the middleware (`res.status(400).json({ message, code: 'bad-request' })`) instead of throwing + `next(err)`. The fix has to live here, in the library: the `next(err)` that dd-trace hooks runs *inside* `schemaMiddleware`, before any consumer code, so no consumer can mitigate it without duplicating a wrapper in every repo.

Key decisions:

- **Changed the default (breaking, `2.0.0`) instead of adding an opt-in flag.** The consumer set is closed and audited — 4 repos (`users`, `login-service`, `offer-builder`, `order-orchestrator`), none of which do anything in their error handler beyond logging + responding for a validation `400`. With a known consumer set, a config flag is ceremony that buys nothing: every consumer has to be touched to bump the version anyway. A per-route flag was also rejected because `login-service` uses the positional `createHandler(schema)` form in 36 of 43 routes, which a `Params`-based flag can't reach without a rewrite.
- **Unexpected (non-validation) errors still propagate via `next(err)`** — the `try/catch` is intentionally kept. Only the expected 4xx stops throwing.
- Removed the now-dead `ExceptionError` class and extracted a single `respondBadRequest` helper so the response shape can't drift between the Joi and Zod branches.
- Response shape (`{ message, code: 'bad-request' }`, HTTP `400`) is unchanged.

The reasoning is recorded in `docs/adr/ADR-0001`.

## How to Test

1. Mount a route with a schema via `createHandler` and send an invalid body.
2. Confirm the response is `400` with body `{ "message": "...", "code": "bad-request" }`.
3. Confirm the consumer's Express error handler is **not** invoked (no `next(err)`) and no error span/log is produced for the `400`.
4. Send a valid request → passes through (`next()`), unchanged.
5. `yarn test` (45 tests), `yarn lint:types`, `yarn lint` all green.

## Impact / Risks

- **Breaking change (`2.0.0`).** Consumers on `^1.0.x` won't receive it until they bump the range to `^2.0.0`. Follow-up PRs needed in the 4 consumers.
- Consumers that added a constant `source: 'unknown'` field via their error handler (`users`, `order-orchestrator`) lose it on validation `400`s — it was always the constant `'unknown'` for these anyway.
- Published as `beta`/`RC` from staging first; `latest` only after promotion to `master` (Jenkins manual approval).

## Related

Closes #16